### PR TITLE
Rename Workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,4 +1,4 @@
-name: build
+name: CI
 on:
   workflow_dispatch:
   pull_request:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,12 +5,13 @@ on:
   push:
     branches: [main]
 jobs:
-  project:
+  build:
+    name: Build
     runs-on: ${{ matrix.os }}-latest
     strategy:
       fail-fast: false
       matrix:
-        os: [windows, ubuntu, macos]
+        os: [Windows, Ubuntu, macOS]
     steps:
       - name: Checkout
         uses: actions/checkout@v4.0.0

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 [![version](https://img.shields.io/github/v/release/threeal/project-starter?style=flat-square)](https://github.com/threeal/project-starter/releases)
 [![license](https://img.shields.io/github/license/threeal/project-starter?style=flat-square)](./LICENSE)
-[![build status](https://img.shields.io/github/actions/workflow/status/threeal/project-starter/build.yaml?branch=main&style=flat-square)](https://github.com/threeal/project-starter/actions/workflows/build.yaml)
+[![build status](https://img.shields.io/github/actions/workflow/status/threeal/project-starter/ci.yaml?branch=main&style=flat-square)](https://github.com/threeal/project-starter/actions/workflows/ci.yaml)
 
 The Project Starter is a [GitHub repository template](https://docs.github.com/en/repositories/creating-and-managing-repositories/creating-a-repository-from-a-template) that provides a minimalistic boilerplate to kickstart any type of project on [GitHub](https://github.com/). Use this template to initialize your project with preconfigured settings recommended for various GitHub projects.
 


### PR DESCRIPTION
This pull request simply rename the `build.yaml` workflow to `ci.yaml` workflow. It also rename jobs and OSs matrix inside that workflow. This pull request resolves #12.