### PR TITLE
Specify Runner OS Version in Workflows

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,11 +7,11 @@ on:
 jobs:
   build:
     name: Build
-    runs-on: ${{ matrix.os }}-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        os: [Windows, Ubuntu, macOS]
+        os: [ubuntu-22.04, macos-14, windows-2022]
     steps:
       - name: Checkout
         uses: actions/checkout@v4.1.7


### PR DESCRIPTION
This pull request resolves #25 by manually specifying the runner OS version to be used in workflows, replacing the default latest version.