### PR TITLE
Remove Dependabot Label Configuration

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -6,7 +6,6 @@ updates:
       interval: daily
     commit-message:
       prefix: chore
-    labels: [chore]
 
   # You can add another configuration here to automatically update the other dependencies of your project.
   # Learn more: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file


### PR DESCRIPTION
This pull request resolves #33 by removing the `labels` entry from the `dependabot.yaml` configuration file.