### PR TITLE
Rename CI Workflow to Build Workflow

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,15 +1,15 @@
-name: CI
+name: Build
 on:
   workflow_dispatch:
   pull_request:
   push:
     branches: [main]
 jobs:
-  build:
-    name: Build
+  build-project:
+    name: Build Project
     runs-on: ubuntu-24.04
     steps:
-      - name: Checkout
+      - name: Checkout Project
         uses: actions/checkout@v4.2.2
 
       # Add steps here to build and test your project.


### PR DESCRIPTION
This pull request resolves #36 by renaming the `ci` workflow to `build` workflow and modifying other names to be more descriptive.