### PR TITLE
Fill Usage Guide in README

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -7,5 +7,5 @@ updates:
     commit-message:
       prefix: chore
 
-  # You can add another configuration here to automatically update the other dependencies of your project.
+  # Add additional configuration here to automatically update other dependencies in your project.
   # Learn more: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -12,5 +12,5 @@ jobs:
       - name: Checkout Project
         uses: actions/checkout@v4.2.2
 
-      # Add steps here to build and test your project.
+      # Add the steps here to build and test your project.
       # Learn more: https://docs.github.com/en/actions/automating-builds-and-tests

--- a/README.md
+++ b/README.md
@@ -12,4 +12,24 @@ The Project Starter is a [GitHub repository template](https://docs.github.com/en
 
 ## Usage
 
-Refer to [this wiki](https://github.com/threeal/project-starter/wiki) for information on how to use this template.
+This guide explains how to use this template to start a new project.
+
+### Create a New Project
+
+Follow [this link](https://github.com/new?template_name=project-starter&template_owner=threeal) to create a new project based on this template. For more information about creating a repository from a template on GitHub, refer to [this documentation](https://docs.github.com/en/repositories/creating-and-managing-repositories/creating-a-repository-from-a-template).
+
+Alternatively, you can clone this repository locally to begin using this template.
+
+### Choose a License
+
+By default, this template is [unlicensed](https://unlicense.org/). Before modifying this template, replace the [`LICENSE`](./LICENSE) file with the license you want to use for the new project. For more information about licensing a repository, refer to [this documentation](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/licensing-a-repository).
+
+Alternatively, you can remove the `LICENSE` file or leave it as-is to keep the new project unlicensed.
+
+### Update the README File
+
+Update the content of this [`README.md`](./README.md) file with a description of the new project. For more information on adding READMEs to a project, refer to [this documentation](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-readmes).
+
+### What's Next?
+
+Next, you can populate the new project with your content. Be sure to update the [`.gitignore`](./.gitignore) file, [`.dependabot.yaml`](./.github/dependabot.yaml) file, and [workflow files](./.github/workflows) according to your project requirements. If you're new to Git or GitHub, refer to [this documentation](https://docs.github.com/en/get-started) for more information.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,3 @@
-<!-- Clear the content of this file and replace it with the description of your project. -->
-<!-- Learn more: https://www.makeareadme.com -->
-
 # Project Starter
 
 The Project Starter is a [GitHub repository template](https://docs.github.com/en/repositories/creating-and-managing-repositories/creating-a-repository-from-a-template) that provides a minimalistic boilerplate to kickstart any type of project on [GitHub](https://github.com/). Use this template to initialize your project with preconfigured settings recommended for various GitHub projects.


### PR DESCRIPTION
This pull request resolves #38 by adding the usage guide to the `README.md` file, replacing the project's wiki. It also updates guidance comments in some files to make them more descriptive.