### PR TITLE
Configure Dependabot Label to Empty

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -6,6 +6,7 @@ updates:
       interval: daily
     commit-message:
       prefix: chore
+    labels: []
 
   # Add additional configuration here to automatically update other dependencies in your project.
   # Learn more: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file


### PR DESCRIPTION
This pull request resolves #43 by configuring Dependabot labels in the `dependabot.yaml` file to an empty array, ensuring that Dependabot won't assign any labels to newly created pull requests.