### PR TITLE
Integrate Lefthook

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A minimalist template for starting a new project on [GitHub](https://github.com/).
 
-This template provides a basic setup for a new GitHub project, including a default `.gitignore` file, [Dependabot](https://docs.github.com/en/code-security/dependabot) configuration, [dprint](https://dprint.dev/) code formatting, and sample [GitHub Actions](https://github.com/features/actions) workflows.
+This template provides a basic setup for a new GitHub project, including a default `.gitignore` file, [Dependabot](https://docs.github.com/en/code-security/dependabot) configuration, [dprint](https://dprint.dev/) code formatting, [lefthook](https://lefthook.dev/) pre-commit hooks, and sample [GitHub Actions](https://github.com/features/actions) workflows.
 
 ## Usage
 
@@ -26,7 +26,7 @@ Update the content of this [`README.md`](./README.md) file with a description of
 
 ### What's Next?
 
-Next, you can populate the new project with your content. Be sure to update the [`.gitignore`](./.gitignore) file, [`.dependabot.yaml`](./.github/dependabot.yaml) file, [`dprint.json`](./dprint.json) configuration, and [workflow files](./.github/workflows) according to your project requirements. If you're new to [Git](https://git-scm.com/) or GitHub, refer to [this documentation](https://docs.github.com/en/get-started) for more information.
+Next, you can populate the new project with your content. Be sure to update the [`.gitignore`](./.gitignore) file, [`.dependabot.yaml`](./.github/dependabot.yaml) file, [`dprint.json`](./dprint.json) configuration, [`lefthook.yaml`](./lefthook.yaml) pre-commit hooks, and [workflow files](./.github/workflows) according to your project requirements. If you're new to [Git](https://git-scm.com/) or GitHub, refer to [this documentation](https://docs.github.com/en/get-started) for more information.
 
 ## Other Templates
 

--- a/lefthook.yaml
+++ b/lefthook.yaml
@@ -1,0 +1,11 @@
+# Modify this Lefthook configuration according to your needs.
+# Learn more: https://lefthook.dev/configuration/index.html
+
+pre-commit:
+  piped: true
+  jobs:
+    - name: fix formatting
+      run: npx --yes prettier --check .
+
+    - name: check diff
+      run: git diff --exit-code {staged_files}


### PR DESCRIPTION
This pull request resolves #47 by integrating [Lefthook](https://lefthook.dev/) into this template, allowing pre-commit hooks to be installed and executed on staged files.