### PR TITLE
Fix Formatting Command in Lefthook Configuration

### DIFF
--- a/lefthook.yaml
+++ b/lefthook.yaml
@@ -5,7 +5,7 @@ pre-commit:
   piped: true
   jobs:
     - name: fix formatting
-      run: npx --yes prettier --check .
+      run: dprint fmt
 
     - name: check diff
       run: git diff --exit-code {staged_files}


### PR DESCRIPTION
This pull request resolves #51 by fixing the `lefthook.yaml` configuration to correctly call `dprint fmt` for formatting the source code in this template.
