### PR TITLE
Use `fail_on_changes` in Lefthook

### DIFF
--- a/lefthook.yaml
+++ b/lefthook.yaml
@@ -3,9 +3,8 @@
 
 pre-commit:
   piped: true
+  fail_on_changes: always
+  fail_on_changes_diff: true
   jobs:
     - name: fix formatting
       run: dprint fmt
-
-    - name: check diff
-      run: git diff --exit-code {staged_files}


### PR DESCRIPTION
This pull request resolves #59 by utilizing `fail_on_changes` and `fail_on_changes_diff` in `lefthook.yaml`, replacing the `check diff` job.