### PR TITLE
Remove Dependabot commit message and label configuration

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -7,6 +7,3 @@ updates:
     directory: /
     schedule:
       interval: daily
-    commit-message:
-      prefix: chore
-    labels: []


### PR DESCRIPTION
This pull request resolves #61 by removing the custom commit message and label configuration from the `dependabot.yaml` file.
