### PR TITLE
Make `.gitignore` rules for dot-prefixed files more specific

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@
 # Learn more: https://git-scm.com/docs/gitignore
 
 .*
-!.git*
+!.github/
+!.gitignore


### PR DESCRIPTION
This pull request resolves #63 by making the rules for including dot-prefixed files in `.gitignore` more specific.