### PR TITLE
Use sentence case for GitHub Actions workflow step names

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -12,8 +12,8 @@ jobs:
     name: Check Formatting
     runs-on: ubuntu-24.04
     steps:
-      - name: Checkout Project
+      - name: Checkout project
         uses: actions/checkout@v6.0.2
 
-      - name: Check Formatting
+      - name: Check formatting
         uses: dprint/check@v2.3


### PR DESCRIPTION
This pull request resolves #67 by updating step names in `check.yaml` workflow to use sentence case instead of title case.