### PR TITLE
Bump `dprint-plugin-json` to version 0.21.3

### DIFF
--- a/dprint.jsonc
+++ b/dprint.jsonc
@@ -3,7 +3,7 @@
 
 {
   "plugins": [
-    "https://plugins.dprint.dev/json-0.20.0.wasm",
+    "https://plugins.dprint.dev/json-0.21.3.wasm",
     "https://plugins.dprint.dev/markdown-0.19.0.wasm",
     "https://plugins.dprint.dev/g-plane/pretty_yaml-v0.5.1.wasm",
   ],


### PR DESCRIPTION
This pull request updates the `dprint-plugin-json` version used by dprint in this template to [0.21.3](https://github.com/dprint/dprint-plugin-json/releases/tag/0.21.3).