### PR TITLE
Bump dprint plugin `pretty-yaml` to version 0.6.0

### DIFF
--- a/dprint.jsonc
+++ b/dprint.jsonc
@@ -5,6 +5,6 @@
   "plugins": [
     "https://plugins.dprint.dev/json-0.20.0.wasm",
     "https://plugins.dprint.dev/markdown-0.19.0.wasm",
-    "https://plugins.dprint.dev/g-plane/pretty_yaml-v0.5.1.wasm",
+    "https://plugins.dprint.dev/g-plane/pretty_yaml-v0.6.0.wasm",
   ],
 }


### PR DESCRIPTION
This pull request updates the version of the `pretty-yaml` plugin used by dprint in this template to [0.6.0](https://github.com/g-plane/pretty_yaml/releases/tag/v0.6.0).