### PR TITLE
add template notice to CLAUDE.md and list it in README

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,8 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
+> **Template notice:** This file describes the template repository itself. If you've created a project from this template, replace this content with guidance specific to your project.
+
 ## About This Repository
 
 This is a minimal, language-agnostic GitHub repository template. It includes formatting enforcement and a CI workflow as a baseline — there is no build system, test suite, or application code. Those are added by projects that use this template.

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Each config file is a starting point — modify it to fit your needs:
 - `lefthook.yaml` — add more pre-commit checks or other Git hooks
 - `.github/workflows/check.yaml` — extend or replace the CI workflow
 - `.github/dependabot.yaml` — adjust update frequency or add more package ecosystems
+- `CLAUDE.md` — replace with guidance for your project's structure, tools, and development workflow (for Claude Code)
 
 ## Language-Specific Templates
 


### PR DESCRIPTION
## Summary

- Adds a template notice to `CLAUDE.md` so Claude Code knows this file describes the template itself and should be replaced when customizing the repo for a real project
- Adds `CLAUDE.md` to the "Customizing" section in `README.md` alongside the other config files users should update

## Test plan

- [x] Verify `dprint check` passes
- [x] Read `CLAUDE.md` and confirm the notice is clear in both template-development and template-consumer contexts
- [x] Read `README.md` and confirm `CLAUDE.md` appears correctly in the Customizing section

🤖 Generated with [Claude Code](https://claude.com/claude-code)