### PR TITLE
Update CI to validate pre-commit hooks

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,5 +14,15 @@ jobs:
       - name: Checkout project
         uses: actions/checkout@v6.0.2
 
-      - name: Check formatting
-        uses: dprint/check@v2.3
+      - name: Install dprint
+        run: |
+          curl -fsSL https://dprint.dev/install.sh | sh
+          echo "$HOME/.dprint/bin" >> $GITHUB_PATH
+
+      - name: Install Lefthook
+        run: |
+          curl -1sLf 'https://dl.cloudsmith.io/public/evilmartians/lefthook/setup.deb.sh' | sudo -E bash
+          sudo apt install lefthook
+
+      - name: Check pre-commit hook
+        run: lefthook run pre-commit --all-files

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,7 +11,7 @@ jobs:
     name: Check
     runs-on: ubuntu-24.04
     steps:
-      - name: Checkout project
+      - name: Checkout
         uses: actions/checkout@v6.0.2
 
       - name: Install dprint

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,4 +30,4 @@ Lefthook manages Git hooks (`lefthook.yaml`). The pre-commit hook runs `dprint f
 
 ## CI
 
-The only CI job (`.github/workflows/ci.yaml`) validates formatting with `dprint check` on PRs and pushes to `main`.
+The only CI job (`.github/workflows/ci.yaml`) validates the pre-commit hook with `lefthook run pre-commit --all-files` on PRs and pushes to `main`.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A minimal GitHub repository template with formatting enforcement and CI/CD ready
 - **Formatting** with [dprint](https://dprint.dev/) — supports JSON, Markdown, and YAML out of the box
 - **Pre-commit hooks** with [Lefthook](https://lefthook.dev/) — auto-formats files before each commit
 - **Dependabot** — keeps GitHub Actions dependencies up to date automatically
-- **CI workflow** — validates formatting on every pull request and push to `main`
+- **CI workflow** — validates the pre-commit hook on every pull request and push to `main`
 
 ## Getting Started
 


### PR DESCRIPTION
Resolves #77.

Instead of running `dprint check` directly, the CI now installs dprint and Lefthook, then validates the pre-commit hook with `lefthook run pre-commit --all-files`. This ensures CI exercises the same formatting check that runs locally on commit.