### PR TITLE
rename workflow to ci.yaml and simplify job name to check

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,14 +1,14 @@
 # Add more jobs here or create additional workflow files in this directory.
 
-name: Check
+name: CI
 on:
   workflow_dispatch:
   pull_request:
   push:
     branches: [main]
 jobs:
-  check-format:
-    name: Check Formatting
+  check:
+    name: Check
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout project

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,4 +30,4 @@ Lefthook manages Git hooks (`lefthook.yaml`). The pre-commit hook runs `dprint f
 
 ## CI
 
-The only CI job (`.github/workflows/check.yaml`) validates formatting with `dprint check` on PRs and pushes to `main`.
+The only CI job (`.github/workflows/ci.yaml`) validates formatting with `dprint check` on PRs and pushes to `main`.

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Each config file is a starting point — modify it to fit your needs:
 
 - `dprint.jsonc` — add or remove dprint plugins for your language
 - `lefthook.yaml` — add more pre-commit checks or other Git hooks
-- `.github/workflows/check.yaml` — extend or replace the CI workflow
+- `.github/workflows/ci.yaml` — extend or replace the CI workflow
 - `.github/dependabot.yaml` — adjust update frequency or add more package ecosystems
 - `CLAUDE.md` — replace with guidance for your project's structure, tools, and development workflow (for Claude Code)
 


### PR DESCRIPTION
Closes #79.

## Summary

- Renamed `.github/workflows/check.yaml` to `ci.yaml` and updated workflow name to `CI`
- Renamed job `check-format` to `check` (display name `Check`)
- Updated file path references in `README.md` and `CLAUDE.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)