### PR TITLE
Bump `dprint-plugin-markdown` to version 0.22.1

### DIFF
--- a/dprint.jsonc
+++ b/dprint.jsonc
@@ -3,7 +3,7 @@
 {
   "plugins": [
     "https://plugins.dprint.dev/json-0.21.3.wasm",
-    "https://plugins.dprint.dev/markdown-0.22.0.wasm",
+    "https://plugins.dprint.dev/markdown-0.22.1.wasm",
     "https://plugins.dprint.dev/g-plane/pretty_yaml-v0.6.0.wasm",
   ],
 }


### PR DESCRIPTION
This pull request updates the `dprint-plugin-markdown` version used by dprint in this template to [0.22.1](https://github.com/dprint/dprint-plugin-markdown/releases/tag/0.22.1).