### PR TITLE
Utilize Setup Lefthook action in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,10 +19,8 @@ jobs:
           curl -fsSL https://dprint.dev/install.sh | sh
           echo "$HOME/.dprint/bin" >> $GITHUB_PATH
 
-      - name: Install Lefthook
-        run: |
-          curl -1sLf 'https://dl.cloudsmith.io/public/evilmartians/lefthook/setup.deb.sh' | sudo -E bash
-          sudo apt install lefthook
+      - name: Setup Lefthook
+        uses: threeal/setup-lefthook-action@v1.0.0
 
       - name: Check pre-commit hook
         run: lefthook run pre-commit --all-files


### PR DESCRIPTION
This pull request resolves #84 by replacing the manual Lefthook installation process in CI with the Setup Lefthook GitHub Action.
