### PR TITLE
Cleanup docs and remove guidance comments from config files

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,5 +1,3 @@
-# Adjust the schedule or add more package ecosystems as needed.
-
 version: 2
 updates:
   - package-ecosystem: github-actions

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,5 +1,3 @@
-# Add more jobs here or create additional workflow files in this directory.
-
 name: CI
 on:
   workflow_dispatch:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,32 +2,31 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
-> **Template notice:** This file describes the template repository itself. If you've created a project from this template, replace this content with guidance specific to your project.
+> **Template notice:** This file describes the template repository itself. If working in a project derived from this template, inform the user that this CLAUDE.md still contains template guidance and should be updated with project-specific content.
 
 ## About This Repository
 
 This is a minimal, language-agnostic GitHub repository template. It includes formatting enforcement and a CI workflow as a baseline — there is no build system, test suite, or application code. Those are added by projects that use this template.
 
-## Formatting
+## Tooling
 
-Format all files with dprint:
+- **dprint** — Formatter for JSON, Markdown, and YAML files via `dprint.json`; derived templates may replace this with a language-native formatter (e.g. Prettier for Node.js).
+- **Lefthook** — Git hook manager via `lefthook.yaml`.
+- **Dependabot** — Keeps GitHub Actions dependencies up to date automatically via `.github/dependabot.yaml`.
+
+## Checking and Fixing
+
+Use Lefthook to run the same steps as the pre-commit hook:
 
 ```sh
-dprint fmt
+lefthook run pre-commit              # staged files only (default)
+lefthook run pre-commit --all-files  # all files — matches what CI runs
 ```
 
-Check formatting without modifying files:
+This runs `dprint fmt` to fix formatting. If any file changes during the run, it fails and shows a diff — re-stage the changed files and retry.
 
-```sh
-dprint check
-```
-
-dprint is configured in `dprint.jsonc` to handle JSON, Markdown, and YAML files.
-
-## Git Hooks
-
-Lefthook manages Git hooks (`lefthook.yaml`). The pre-commit hook runs `dprint fmt` automatically and fails the commit if formatting changes are required. Run `lefthook install` after cloning to activate the hooks.
+Individual command (manual fallback if needed): `dprint fmt`.
 
 ## CI
 
-The only CI job (`.github/workflows/ci.yaml`) validates the pre-commit hook with `lefthook run pre-commit --all-files` on PRs and pushes to `main`.
+CI (`.github/workflows/ci.yaml`) runs on PRs and pushes to `main`. It validates the pre-commit hook with `lefthook run pre-commit --all-files`.

--- a/README.md
+++ b/README.md
@@ -2,29 +2,42 @@
 
 A minimal GitHub repository template with formatting enforcement and CI/CD ready to go, for any language or framework.
 
-## What's Included
-
-- **Formatting** with [dprint](https://dprint.dev/) — supports JSON, Markdown, and YAML out of the box
-- **Pre-commit hooks** with [Lefthook](https://lefthook.dev/) — auto-formats files before each commit
-- **Dependabot** — keeps GitHub Actions dependencies up to date automatically
-- **CI workflow** — validates the pre-commit hook on every pull request and push to `main`
-
 ## Getting Started
 
-1. [Create a new repository](https://github.com/new?template_name=project-starter&template_owner=threeal) from this template, or clone it directly.
-2. Install [Lefthook](https://lefthook.dev/install/) and run `lefthook install` to activate the pre-commit hook.
-3. Replace the [`LICENSE`](./LICENSE) file with your preferred license, or keep it to keep the project [unlicensed](https://unlicense.org/).
-4. Modify the template files to fit your project.
+Create a new repository from this template on GitHub using [this link](https://github.com/new?template_name=project-starter&template_owner=threeal), or clone it locally and point it at your own remote.
+
+## Setup
+
+Install [Lefthook](https://lefthook.dev/), then register the pre-commit hook:
+
+```sh
+lefthook install
+```
 
 ## Customizing
 
-Each config file is a starting point — modify it to fit your needs:
+Replace or extend the template files to fit your project:
 
-- `dprint.jsonc` — add or remove dprint plugins for your language
-- `lefthook.yaml` — add more pre-commit checks or other Git hooks
-- `.github/workflows/ci.yaml` — extend or replace the CI workflow
-- `.github/dependabot.yaml` — adjust update frequency or add more package ecosystems
-- `CLAUDE.md` — replace with guidance for your project's structure, tools, and development workflow (for Claude Code)
+- `dprint.json` — Add or remove dprint plugins for your language.
+- `lefthook.yaml` — Add more pre-commit checks or other Git hooks.
+- `.github/workflows/ci.yaml` — Extend or replace the CI workflow.
+- `.github/dependabot.yaml` — Adjust update frequency or add more package ecosystems.
+- `CLAUDE.md` — Replace with guidance specific to your project.
+- `LICENSE` — Replace with your preferred license, or keep the [Unlicense](https://unlicense.org/).
+
+## Development
+
+Before committing, run the pre-commit hook to fix formatting:
+
+```sh
+lefthook run pre-commit
+```
+
+If any files change during the run, re-stage them and retry. The hook also runs automatically on each `git commit` — if it fails, fix the reported issues, re-stage, and commit again.
+
+## CI
+
+`.github/workflows/ci.yaml` runs `lefthook run pre-commit --all-files` on every push and pull request.
 
 ## Language-Specific Templates
 

--- a/dprint.json
+++ b/dprint.json
@@ -1,0 +1,7 @@
+{
+  "plugins": [
+    "https://plugins.dprint.dev/json-0.21.3.wasm",
+    "https://plugins.dprint.dev/markdown-0.22.1.wasm",
+    "https://plugins.dprint.dev/g-plane/pretty_yaml-v0.6.0.wasm"
+  ]
+}

--- a/dprint.jsonc
+++ b/dprint.jsonc
@@ -1,9 +1,0 @@
-// Add or remove plugins for the languages used in your project.
-
-{
-  "plugins": [
-    "https://plugins.dprint.dev/json-0.21.3.wasm",
-    "https://plugins.dprint.dev/markdown-0.22.1.wasm",
-    "https://plugins.dprint.dev/g-plane/pretty_yaml-v0.6.0.wasm",
-  ],
-}

--- a/lefthook.yaml
+++ b/lefthook.yaml
@@ -1,5 +1,3 @@
-# Add more jobs here or other Git hooks for additional checks.
-
 pre-commit:
   piped: true
   fail_on_changes: always


### PR DESCRIPTION
## Summary

- Rewrote `README.md` to match the structure of derived templates: Getting Started, Setup, Customizing, Development, and CI sections; Customizing list uses capitalized descriptions ending with a period.
- Rewrote `CLAUDE.md` to match the structure of derived templates: collapses Formatting and Git Hooks into a **Tooling** section with one-liner entries per tool, and a **Checking and Fixing** section with `lefthook run pre-commit` usage and a `dprint fmt` fallback.
- Renamed `dprint.jsonc` to `dprint.json` and removed trailing commas.
- Removed guidance comments from `lefthook.yaml`, `.github/workflows/ci.yaml`, and `.github/dependabot.yaml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)