### PR TITLE
Improve lists in README.md and CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,9 +10,9 @@ This is a minimal, language-agnostic GitHub repository template. It includes for
 
 ## Tooling
 
+- **Dependabot** — Keeps GitHub Actions dependencies up to date automatically via `.github/dependabot.yaml`.
 - **dprint** — Formatter for JSON, Markdown, and YAML files via `dprint.json`; derived templates may replace this with a language-native formatter (e.g. Prettier for Node.js).
 - **Lefthook** — Git hook manager via `lefthook.yaml`.
-- **Dependabot** — Keeps GitHub Actions dependencies up to date automatically via `.github/dependabot.yaml`.
 
 ## Checking and Fixing
 

--- a/README.md
+++ b/README.md
@@ -18,12 +18,13 @@ lefthook install
 
 Replace or extend the template files to fit your project:
 
-- `dprint.json` — Add or remove dprint plugins for your language.
-- `lefthook.yaml` — Add more pre-commit checks or other Git hooks.
-- `.github/workflows/ci.yaml` — Extend or replace the CI workflow.
-- `.github/dependabot.yaml` — Adjust update frequency or add more package ecosystems.
-- `CLAUDE.md` — Replace with guidance specific to your project.
-- `LICENSE` — Replace with your preferred license, or keep the [Unlicense](https://unlicense.org/).
+- **`dprint.json`** — Add or remove dprint plugins for your language.
+- **`lefthook.yaml`** — Add more pre-commit checks or other Git hooks.
+- **`.github/workflows/ci.yaml`** — Extend or replace the CI workflow.
+- **`.github/dependabot.yaml`** — Adjust update frequency or add more package ecosystems.
+- **`README.md`** — Replace with a description of your project.
+- **`CLAUDE.md`** — Replace with guidance specific to your project.
+- **`LICENSE`** — Replace with your preferred license, or keep the [Unlicense](https://unlicense.org/).
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -18,13 +18,13 @@ lefthook install
 
 Replace or extend the template files to fit your project:
 
-- **`dprint.json`** — Add or remove dprint plugins for your language.
-- **`lefthook.yaml`** — Add more pre-commit checks or other Git hooks.
 - **`.github/workflows/ci.yaml`** — Extend or replace the CI workflow.
 - **`.github/dependabot.yaml`** — Adjust update frequency or add more package ecosystems.
-- **`README.md`** — Replace with a description of your project.
 - **`CLAUDE.md`** — Replace with guidance specific to your project.
+- **`dprint.json`** — Add or remove dprint plugins for your language.
+- **`lefthook.yaml`** — Add more pre-commit checks or other Git hooks.
 - **`LICENSE`** — Replace with your preferred license, or keep the [Unlicense](https://unlicense.org/).
+- **`README.md`** — Replace with a description of your project.
 
 ## Development
 


### PR DESCRIPTION
## Summary

Changes to the Customizing section in `README.md`:

- Bold each file title (`**\`file\`**`) to visually separate it from the description, which may itself reference other files
- Add `README.md` to the list so users know to replace it when deriving a project from this template
- Sort entries with directories first, then root-level files, each in naming order

Changes to the Tooling section in `CLAUDE.md`:

- Sort tools alphabetically by name