### PR TITLE
Improve README.md and CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,27 +6,37 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## About This Repository
 
-This is a minimal, language-agnostic GitHub repository template. It includes formatting enforcement and a CI workflow as a baseline — there is no build system, test suite, or application code. Those are added by projects that use this template.
+This is a minimal, language-agnostic starter template with formatting enforcement and a CI workflow as a baseline. There is no build system, test suite, or application code — those are added by projects that use this template.
 
 ## Tooling
 
-- **Dependabot** — Keeps GitHub Actions dependencies up to date automatically via `.github/dependabot.yaml`.
-- **dprint** — Formatter for JSON, Markdown, and YAML files via `dprint.json`; derived templates may replace this with a language-native formatter (e.g. Prettier for Node.js).
-- **Lefthook** — Git hook manager via `lefthook.yaml`.
+### Dependabot
+
+Keeps GitHub Actions dependencies up to date automatically via `.github/dependabot.yaml`.
+
+### dprint
+
+Formatter for JSON, Markdown, and YAML files via `dprint.json`.
+
+### GitHub Actions
+
+Automates CI. Workflow files:
+
+- **`.github/workflows/ci.yaml`** — Triggers on push to `main`, pull requests, and manual dispatch. Runs `lefthook run pre-commit --all-files` to validate formatting.
+
+### Lefthook
+
+Git hook manager configured in `lefthook.yaml`. The pre-commit hook:
+
+- Fixes formatting with `dprint fmt`.
 
 ## Checking and Fixing
 
-Use Lefthook to run the same steps as the pre-commit hook:
+Run the pre-commit hook:
 
 ```sh
 lefthook run pre-commit              # staged files only (default)
 lefthook run pre-commit --all-files  # all files — matches what CI runs
 ```
 
-This runs `dprint fmt` to fix formatting. If any file changes during the run, it fails and shows a diff — re-stage the changed files and retry.
-
-Individual command (manual fallback if needed): `dprint fmt`.
-
-## CI
-
-CI (`.github/workflows/ci.yaml`) runs on PRs and pushes to `main`. It validates the pre-commit hook with `lefthook run pre-commit --all-files`.
+If any file changes during the run, re-stage the changed files and retry.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Project Starter
 
-A minimal GitHub repository template with formatting enforcement and CI/CD ready to go, for any language or framework.
+A minimal template for any language or framework. Ships pre-configured with formatting enforcement, pre-commit hooks, and CI.
 
 ## Getting Started
 
@@ -8,7 +8,7 @@ Create a new repository from this template on GitHub using [this link](https://g
 
 ## Setup
 
-Install [Lefthook](https://lefthook.dev/), then register the pre-commit hook:
+Install [Lefthook](https://lefthook.dev/) and [dprint](https://dprint.dev/), then register the pre-commit hook:
 
 ```sh
 lefthook install
@@ -34,20 +34,18 @@ Before committing, run the pre-commit hook to fix formatting:
 lefthook run pre-commit
 ```
 
-If any files change during the run, re-stage them and retry. The hook also runs automatically on each `git commit` — if it fails, fix the reported issues, re-stage, and commit again.
+If any file changes during the run, re-stage the changed files and retry. The hook also runs automatically on each `git commit` — if it fails, re-stage the changed files and commit again.
 
-## CI
-
-`.github/workflows/ci.yaml` runs `lefthook run pre-commit --all-files` on every push and pull request.
+After committing, push to `main` or open a pull request from another branch — CI will run the pre-commit hook across all files.
 
 ## Language-Specific Templates
 
 For a more opinionated starting point in a specific language or framework:
 
-- [Action Starter](https://github.com/threeal/action-starter)
-- [C++ Starter](https://github.com/threeal/cpp-starter)
-- [CMake Starter](https://github.com/threeal/cmake-starter)
-- [Composite Action Starter](https://github.com/threeal/composite-action-starter)
-- [Discord Bot Starter](https://github.com/threeal/discord-bot-starter)
-- [Node.js Starter](https://github.com/threeal/nodejs-starter)
-- [Python Starter](https://github.com/threeal/python-starter)
+- **[Action Starter](https://github.com/threeal/action-starter)** — JavaScript GitHub Action projects.
+- **[C++ Starter](https://github.com/threeal/cpp-starter)** — C++ projects.
+- **[CMake Starter](https://github.com/threeal/cmake-starter)** — CMake projects.
+- **[Composite Action Starter](https://github.com/threeal/composite-action-starter)** — Composite GitHub Action projects.
+- **[Discord Bot Starter](https://github.com/threeal/discord-bot-starter)** — Discord bot projects.
+- **[Node.js Starter](https://github.com/threeal/nodejs-starter)** — Node.js projects.
+- **[Python Starter](https://github.com/threeal/python-starter)** — Python projects.


### PR DESCRIPTION
## Summary

- Rewrote `README.md` description and Development section to follow the style of other starter templates; added dprint to Setup; replaced the CI section with a push/PR note in Development; added descriptions to the Language-Specific Templates list.
- Restructured `CLAUDE.md` Tooling into named subsections (Dependabot, dprint, GitHub Actions, Lefthook) with the pre-commit hook steps listed under Lefthook; simplified the Checking and Fixing section to just the commands and restage instruction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)